### PR TITLE
chore: 🔧 Downgraded forge version to 1.16.4-35.1+ still compatible wi…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.daemon=false
-minecraft_version=1.16.5
-forge_version=36.0.+
+minecraft_version=1.16.4
+forge_version=35.1.+
 mod_version=2.1.1
 mcp_mappings=20200916-1.16.2
 jei_mc_version=1.16.4


### PR DESCRIPTION
…th 1.16.5 but allows 1.16.4