### PR TITLE
fix: 🐛 Fixed issue in upgrade swapping logic which allowed items that…

### DIFF
--- a/src/main/java/net/p3pp3rf1y/sophisticatedbackpacks/common/gui/BackpackContainer.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedbackpacks/common/gui/BackpackContainer.java
@@ -394,7 +394,7 @@ public class BackpackContainer extends Container {
 
 			getSlot(slotId).putStack(cursorStack);
 			return ItemStack.EMPTY;
-		} else if (isUpgradeSlot(slotId) && getSlot(slotId) instanceof BackpackUpgradeSlot) {
+		} else if (isUpgradeSlot(slotId) && getSlot(slotId) instanceof BackpackUpgradeSlot && getSlot(slotId).isItemValid(player.inventory.getItemStack())) {
 			BackpackUpgradeSlot upgradeSlot = (BackpackUpgradeSlot) getSlot(slotId);
 			ItemStack cursorStack = player.inventory.getItemStack();
 			ItemStack slotStack = upgradeSlot.getStack();


### PR DESCRIPTION
… are not backpack upgrades to end up in upgrade slots and then crash the game.