### PR TITLE
Faster shape computation and lower memory usage

### DIFF
--- a/src/main/java/net/p3pp3rf1y/sophisticatedbackpacks/backpack/BackpackShapes.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedbackpacks/backpack/BackpackShapes.java
@@ -17,31 +17,18 @@ public class BackpackShapes {
 
 	private static final Map<Integer, VoxelShape> SHAPES = new HashMap<>();
 
-	public static VoxelShape rotateShape(Direction dir, VoxelShape shape) {
-		VoxelShape ret = shape;
-
-		int times = (dir.get2DDataValue() + 4) % 4;
-		for (int i = 0; i < times; i++) {
-			List<VoxelShape> shapes = new ArrayList<>();
-			ret.forAllBoxes((minX, minY, minZ, maxX, maxY, maxZ) -> shapes.add(Shapes.box(1 - maxZ, minY, minX, 1 - minZ, maxY, maxX)));
-			ret = shapes.stream().reduce((v1, v2) -> Shapes.join(v1, v2, BooleanOp.OR)).orElse(Shapes.empty());
-		}
-
-		return ret;
-	}
-
 	public static VoxelShape getShape(Direction dir, boolean leftTank, boolean rightTank, boolean battery) {
 		int key = getKey(dir, leftTank, rightTank, battery);
 		return SHAPES.computeIfAbsent(key, k -> BackpackShapes.composeShape(dir, leftTank, rightTank, battery));
 	}
 
 	private static VoxelShape composeShape(Direction dir, boolean leftTank, boolean rightTank, boolean battery) {
-		List<VoxelShape> shapes = new ArrayList<>();
+		List<RotatedShapes> shapes = new ArrayList<>();
 		shapes.add(BODY);
 		shapes.add(leftTank ? LEFT_TANK : LEFT_POUCHES);
 		shapes.add(rightTank ? RIGHT_TANK : RIGHT_POUCHES);
 		shapes.add(battery ? BATTERY : FRONT_POUCH);
-		return rotateShape(dir, shapes.stream().reduce((v1, v2) -> Shapes.join(v1, v2, BooleanOp.OR)).orElse(Shapes.empty()));
+		return or(shapes.stream().map(r -> r.getRotatedShape(dir)));
 	}
 
 	private static int getKey(Direction dir, boolean leftTank, boolean rightTank, boolean battery) {
@@ -52,7 +39,7 @@ public class BackpackShapes {
 		return value ? 1 : 0;
 	}
 
-	private static final VoxelShape BODY = Stream.of(
+	private static final RotatedShapes BODY = new RotatedShapes(
 			Block.box(5.25, 0, 4, 5.75, 12.5, 5),
 			Block.box(4.25, 0, 4, 5.25, 12.5, 5),
 			Block.box(3.75, 0, 4, 4.25, 12.5, 5),
@@ -72,9 +59,9 @@ public class BackpackShapes {
 			Block.box(10.5, 7, 10.75, 11.5, 9, 11.5),
 			Block.box(3, 0, 5, 13, 13, 11),
 			Block.box(4, 1, 4.5, 12, 12, 5)
-	).reduce((v1, v2) -> Shapes.join(v1, v2, BooleanOp.OR)).get();
+	);
 
-	private static final VoxelShape BATTERY = Stream.of(
+	private static final RotatedShapes BATTERY = new RotatedShapes(
 			Block.box(4, 0, 11, 12, 6, 14),
 			Block.box(6, 5.25, 11.5, 7, 6.25, 12.5),
 			Block.box(7.25, 5.25, 11.5, 8.25, 6.25, 12.5),
@@ -92,9 +79,9 @@ public class BackpackShapes {
 			Block.box(11.25, 0.25, 10.25, 12.25, 1.25, 14.25),
 			Block.box(4.5, 0.25, 13.25, 11.5, 1.25, 14.25),
 			Block.box(3.75, 0.25, 10.25, 4.75, 1.25, 14.25)
-	).reduce((v1, v2) -> Shapes.join(v1, v2, BooleanOp.OR)).get();
+	);
 
-	private static final VoxelShape LEFT_TANK = Stream.of(
+	private static final RotatedShapes LEFT_TANK = new RotatedShapes(
 			Block.box(2.5, 1.5, 6, 3.5, 7.5, 10),
 			Block.box(0.5, 10.5, 6.5, 3.5, 11.5, 9.5),
 			Block.box(0, 9.5, 6, 3, 10.5, 10),
@@ -102,9 +89,9 @@ public class BackpackShapes {
 			Block.box(0, 7.5, 6, 3, 8.5, 10),
 			Block.box(0, 0.5, 6, 3, 1.5, 10),
 			Block.box(0.5, 1.5, 6.5, 2.5, 7.5, 9.5)
-	).reduce((v1, v2) -> Shapes.join(v1, v2, BooleanOp.OR)).get();
+	);
 
-	private static final VoxelShape RIGHT_TANK = Stream.of(
+	private static final RotatedShapes RIGHT_TANK = new RotatedShapes(
 			Block.box(12.5, 1.5, 6, 13.5, 7.5, 10),
 			Block.box(12.5, 10.5, 6.5, 15.5, 11.5, 9.5),
 			Block.box(13, 9.5, 6, 16, 10.5, 10),
@@ -112,9 +99,9 @@ public class BackpackShapes {
 			Block.box(13, 7.5, 6, 16, 8.5, 10),
 			Block.box(13, 0.5, 6, 16, 1.5, 10),
 			Block.box(13.5, 1.5, 6.5, 15.5, 7.5, 9.5)
-	).reduce((v1, v2) -> Shapes.join(v1, v2, BooleanOp.OR)).get();
+	);
 
-	private static final VoxelShape LEFT_POUCHES = Stream.of(
+	private static final RotatedShapes LEFT_POUCHES = new RotatedShapes(
 			Block.box(1, 2, 5.5, 3, 6, 10.5),
 			Block.box(1, 1, 5.5, 3, 2, 10.5),
 			Block.box(1, 0, 5.5, 3, 1, 10.5),
@@ -123,9 +110,9 @@ public class BackpackShapes {
 			Block.box(2, 7, 5.5, 3, 11, 10.5),
 			Block.box(1.75, 8, 7.5, 2, 10, 8.5),
 			Block.box(2, 9, 5.5, 4, 10, 10.5)
-	).reduce((v1, v2) -> Shapes.join(v1, v2, BooleanOp.OR)).get();
+	);
 
-	private static final VoxelShape RIGHT_POUCHES = Stream.of(
+	private static final RotatedShapes RIGHT_POUCHES = new RotatedShapes(
 			Block.box(13, 2, 5.5, 15, 6, 10.5),
 			Block.box(13, 1, 5.5, 15, 2, 10.5),
 			Block.box(13, 0, 5.5, 15, 1, 10.5),
@@ -134,14 +121,46 @@ public class BackpackShapes {
 			Block.box(13, 7, 5.5, 14, 11, 10.5),
 			Block.box(14, 8, 7.5, 14.25, 10, 8.5),
 			Block.box(12, 9, 5.5, 14, 10, 10.5)
-	).reduce((v1, v2) -> Shapes.join(v1, v2, BooleanOp.OR)).get();
+	);
 
-	private static final VoxelShape FRONT_POUCH = Stream.of(
+	private static final RotatedShapes FRONT_POUCH = new RotatedShapes(
 			Block.box(4, 2, 11, 12, 6, 13),
 			Block.box(4, 1, 11, 12, 2, 13),
 			Block.box(4, 0, 11, 12, 1, 13),
 			Block.box(5, 3, 13, 6, 5, 13.25),
 			Block.box(10, 3, 13, 11, 5, 13.25),
 			Block.box(4, 4, 11, 12, 5, 13)
-	).reduce((v1, v2) -> Shapes.join(v1, v2, BooleanOp.OR)).get();
+	);
+
+	private static class RotatedShapes {
+		private final VoxelShape[] rotatedShapes = new VoxelShape[4];
+
+		private RotatedShapes(VoxelShape... shapes) {
+			this.rotatedShapes[0] = or(Stream.of(shapes));
+		}
+
+		public VoxelShape getRotatedShape(Direction to) {
+			int index = (to.get2DDataValue() + 4) % 4;
+			if (rotatedShapes[index] == null) {
+				for (int i = 1; i <= index; ++i) {
+					if (rotatedShapes[i] == null) {
+						rotatedShapes[i] = rotateShapeOnce(rotatedShapes[i - 1]);
+					}
+				}
+			}
+			return rotatedShapes[index];
+		}
+
+		private static VoxelShape rotateShapeOnce(VoxelShape shape) {
+			List<VoxelShape> shapes = new ArrayList<>();
+			shape.forAllBoxes((minX, minY, minZ, maxX, maxY, maxZ) -> shapes.add(Shapes.box(1 - maxZ, minY, minX, 1 - minZ, maxY, maxX)));
+			return or(shapes.stream());
+		}
+	}
+
+	private static VoxelShape or(Stream<VoxelShape> shapes) {
+		return shapes.reduce((v1, v2) -> Shapes.joinUnoptimized(v1, v2, BooleanOp.OR))
+			.map(VoxelShape::optimize)
+			.orElse(Shapes.empty());
+	}
 }

--- a/src/main/java/net/p3pp3rf1y/sophisticatedbackpacks/client/render/BackpackLayerRenderer.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedbackpacks/client/render/BackpackLayerRenderer.java
@@ -34,12 +34,14 @@ public class BackpackLayerRenderer<T extends LivingEntity, M extends HumanoidMod
 		entityTranslations.put(EntityType.ENDERMAN, new Vec3(0, -0.8, 0));
 	}
 
-	private final BackpackModel model;
+	private static BackpackModel model;
 
 	public BackpackLayerRenderer(RenderLayerParent<T, M> entityRendererIn) {
 		super(entityRendererIn);
-		EntityModelSet entityModels = Minecraft.getInstance().getEntityModels();
-		model = new BackpackModel(entityModels.bakeLayer(BACKPACK_LAYER));
+		if (model == null) {
+			EntityModelSet entityModels = Minecraft.getInstance().getEntityModels();
+			model = new BackpackModel(entityModels.bakeLayer(BACKPACK_LAYER));
+		}
 	}
 
 	@Override


### PR DESCRIPTION
1. Faster shape computation: The first commit reduces runtime for this loop from 8-10 seconds to 200-300 ms. MC runs a similar loop during startup.
```java
for (var regObj : BLOCKS.getEntries()) {
	for (var state : regObj.get().getStateDefinition().getPossibleStates()) {
		state.getShape(null, null, null);
	}
}
```

2. Only create a single instance of `BackpackModel`: The model does not depend on the entity renderer, and is a relatively large object. On FC1 (without my change) there are about 150 instances in memory, in total about 25 MB. 25 MB isn't a massive amount, but IMO still enough to optimize it if it only takes a few lines.