### PR TITLE
fix: 🐛 Replaced Quark's easy transfer logic with one that's compatibl…

### DIFF
--- a/src/main/java/net/p3pp3rf1y/sophisticatedbackpacks/common/gui/BackpackContainer.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedbackpacks/common/gui/BackpackContainer.java
@@ -73,6 +73,10 @@ public class BackpackContainer extends Container implements ISyncedContainer {
 	private static final String UPGRADE_SLOT_TAG = "upgradeSlot";
 	private static final String ACTION_TAG = "action";
 
+	public IBackpackWrapper getBackpackWrapper() {
+		return backpackWrapper;
+	}
+
 	private final IBackpackWrapper backpackWrapper;
 	private final PlayerEntity player;
 	private int backpackSlotNumber = -1;

--- a/src/main/java/net/p3pp3rf1y/sophisticatedbackpacks/common/gui/BackpackInventorySlot.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedbackpacks/common/gui/BackpackInventorySlot.java
@@ -1,66 +1,27 @@
 package net.p3pp3rf1y.sophisticatedbackpacks.common.gui;
 
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.inventory.Inventory;
+import net.minecraft.inventory.container.Slot;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.items.IItemHandler;
-import net.minecraftforge.items.IItemHandlerModifiable;
-import net.minecraftforge.items.SlotItemHandler;
 import net.p3pp3rf1y.sophisticatedbackpacks.api.IBackpackWrapper;
 import net.p3pp3rf1y.sophisticatedbackpacks.api.ISlotChangeResponseUpgrade;
 import net.p3pp3rf1y.sophisticatedbackpacks.backpack.wrapper.BackpackInventoryHandler;
 
 import javax.annotation.Nonnull;
 
-public class BackpackInventorySlot extends SlotItemHandler {
+public class BackpackInventorySlot extends Slot {
+	private static final IInventory EMPTY_INVENTORY = new Inventory(0);
+
 	private final boolean isClientSide;
 	private final IBackpackWrapper backpackWrapper;
 	private final BackpackInventoryHandler inventoryHandler;
 	private final int slotIndex;
 
-	private static IItemHandler wrapWithNoInsertAndExtractWrapper(IItemHandlerModifiable handler) {
-		return new IItemHandlerModifiable() {
-			@Override
-			public void setStackInSlot(int slot, @Nonnull ItemStack stack) {
-				handler.setStackInSlot(slot, stack);
-			}
-
-			@Override
-			public int getSlots() {
-				return handler.getSlots();
-			}
-
-			@Nonnull
-			@Override
-			public ItemStack getStackInSlot(int slot) {
-				return handler.getStackInSlot(slot);
-			}
-
-			@Nonnull
-			@Override
-			public ItemStack insertItem(int slot, @Nonnull ItemStack stack, boolean simulate) {
-				return stack;
-			}
-
-			@Nonnull
-			@Override
-			public ItemStack extractItem(int slot, int amount, boolean simulate) {
-				return ItemStack.EMPTY;
-			}
-
-			@Override
-			public int getSlotLimit(int slot) {
-				return handler.getSlotLimit(slot);
-			}
-
-			@Override
-			public boolean isItemValid(int slot, @Nonnull ItemStack stack) {
-				return handler.isItemValid(slot, stack);
-			}
-		};
-	}
-
 	public BackpackInventorySlot(boolean isClientSide, IBackpackWrapper backpackWrapper, BackpackInventoryHandler inventoryHandler, int slotIndex, int lineIndex, int yPosition) {
-		super(wrapWithNoInsertAndExtractWrapper(inventoryHandler), slotIndex, 8 + lineIndex * 18, yPosition);
+		super(EMPTY_INVENTORY, slotIndex, 8 + lineIndex * 18, yPosition);
 		this.isClientSide = isClientSide;
 		this.backpackWrapper = backpackWrapper;
 		this.inventoryHandler = inventoryHandler;
@@ -82,22 +43,49 @@ public class BackpackInventorySlot extends SlotItemHandler {
 		}
 	}
 
+	@Nonnull
+	@Override
+	public ItemStack getItem() {
+		return inventoryHandler.getStackInSlot(slotIndex);
+	}
+
+	@Override
+	public boolean mayPlace(ItemStack stack) {
+		if (stack.isEmpty()) {
+			return false;
+		}
+		return inventoryHandler.isItemValid(slotIndex, stack);
+	}
+
+	@Override
+	public void set(ItemStack stack) {
+		inventoryHandler.setStackInSlot(slotIndex, stack);
+		setChanged();
+	}
+
+	@Override
+	public int getMaxStackSize() {
+		return inventoryHandler.getSlotLimit(slotIndex);
+	}
+
+	@Override
+	public void onQuickCraft(@Nonnull ItemStack oldStackIn, @Nonnull ItemStack newStackIn) {
+		//noop
+	}
+
 	@Override
 	public int getMaxStackSize(ItemStack stack) {
 		return inventoryHandler.getStackLimit(slotIndex, stack);
 	}
 
 	@Override
-	public boolean mayPickup(PlayerEntity playerIn)
-	{
+	public boolean mayPickup(PlayerEntity playerIn) {
 		return !inventoryHandler.extractItem(slotIndex, 1, true).isEmpty();
 	}
 
 	@Override
 	@Nonnull
-	public ItemStack remove(int amount)
-	{
+	public ItemStack remove(int amount) {
 		return inventoryHandler.extractItem(slotIndex, amount, false);
 	}
-
 }

--- a/src/main/java/net/p3pp3rf1y/sophisticatedbackpacks/compat/quark/QuarkButtonReplacer.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedbackpacks/compat/quark/QuarkButtonReplacer.java
@@ -1,0 +1,67 @@
+package net.p3pp3rf1y.sophisticatedbackpacks.compat.quark;
+
+import net.minecraft.client.gui.widget.button.Button;
+import net.minecraft.inventory.container.Slot;
+import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
+import net.p3pp3rf1y.sophisticatedbackpacks.SophisticatedBackpacks;
+import net.p3pp3rf1y.sophisticatedbackpacks.client.gui.BackpackScreen;
+import net.p3pp3rf1y.sophisticatedbackpacks.network.PacketHandler;
+import vazkii.quark.content.management.client.gui.MiniInventoryButton;
+
+class QuarkButtonReplacer implements BackpackScreen.IButtonReplacer {
+	private static final int INSERT_TYPE = 1;
+	private static final int EXTRACT_TYPE = 2;
+	private static final int SORT_TYPE = 0;
+
+	@Override
+	public boolean shouldReplace(BackpackScreen screen, Button button) {
+		if (!(button instanceof MiniInventoryButton)) {
+			return false;
+		}
+		try {
+			//this logic isn't ideal by far, but best that can be used to identify the actual sort backpack button
+			MiniInventoryButton miniInventoryButton = ((MiniInventoryButton) button);
+			int type = ObfuscationReflectionHelper.getPrivateValue(MiniInventoryButton.class, miniInventoryButton, "type");
+			Slot slot = screen.getMenu().getSlot(8);
+			int x = screen.getGuiLeft() + slot.x + 6;
+			int y = screen.getGuiTop() + slot.y - 13;
+			return isBackpackSortButton(button, type, x, y) || isInsertButton(type) || isExtractButton(type);
+		}
+		catch (ObfuscationReflectionHelper.UnableToFindFieldException | ObfuscationReflectionHelper.UnableToAccessFieldException | NullPointerException ex) {
+			SophisticatedBackpacks.LOGGER.error("Error checking for Quark Sort button ", ex);
+			return false;
+		}
+	}
+
+	private boolean isExtractButton(int type) {
+		return type == EXTRACT_TYPE;
+	}
+
+	private boolean isInsertButton(int type) {
+		return type == INSERT_TYPE;
+	}
+
+	private boolean isBackpackSortButton(Button button, int type, int x, int y) {
+		return type == SORT_TYPE && button.x == x && button.y == y;
+	}
+
+	@Override
+	public Button replace(BackpackScreen screen, Button button) {
+		MiniInventoryButton miniInventoryButton = ((MiniInventoryButton) button);
+		int type = ObfuscationReflectionHelper.getPrivateValue(MiniInventoryButton.class, miniInventoryButton, "type");
+		Slot slot = screen.getMenu().getSlot(8);
+		int x = screen.getGuiLeft() + slot.x + 6;
+		int y = screen.getGuiTop() + slot.y - 13;
+		if (isBackpackSortButton(button, type, x, y)) {
+			return new MiniInventoryButton(screen, SORT_TYPE, button.x - screen.getGuiLeft(), button.y - screen.getGuiTop(), "quark.gui.button.sort_container",
+					b -> screen.getMenu().sort());
+		} else if (isInsertButton(type)) {
+			return new MiniInventoryButton(screen, INSERT_TYPE, button.x - screen.getGuiLeft(), button.y - screen.getGuiTop(), "quark.gui.button.insert",
+					b -> PacketHandler.sendToServer(new TransferMessage(false)));
+		} else if (isExtractButton(type)) {
+			return new MiniInventoryButton(screen, EXTRACT_TYPE, button.x - screen.getGuiLeft(), button.y - screen.getGuiTop(), "quark.gui.button.extract",
+					b -> PacketHandler.sendToServer(new TransferMessage(true)));
+		}
+		return button;
+	}
+}

--- a/src/main/java/net/p3pp3rf1y/sophisticatedbackpacks/compat/quark/QuarkCompat.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedbackpacks/compat/quark/QuarkCompat.java
@@ -1,15 +1,11 @@
 package net.p3pp3rf1y.sophisticatedbackpacks.compat.quark;
 
-import net.minecraft.client.gui.widget.button.Button;
-import net.minecraft.inventory.container.Slot;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.fml.DistExecutor;
-import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
-import net.p3pp3rf1y.sophisticatedbackpacks.SophisticatedBackpacks;
 import net.p3pp3rf1y.sophisticatedbackpacks.client.gui.BackpackScreen;
 import net.p3pp3rf1y.sophisticatedbackpacks.compat.ICompat;
+import net.p3pp3rf1y.sophisticatedbackpacks.network.PacketHandler;
 import vazkii.quark.base.module.ModuleLoader;
-import vazkii.quark.content.management.client.gui.MiniInventoryButton;
 import vazkii.quark.content.management.module.InventorySortingModule;
 
 public class QuarkCompat implements ICompat {
@@ -17,33 +13,10 @@ public class QuarkCompat implements ICompat {
 	public void setup() {
 		DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> () -> {
 			if (ModuleLoader.INSTANCE.isModuleEnabled(InventorySortingModule.class)) {
-				BackpackScreen.setButtonReplacer(new BackpackScreen.IButtonReplacer() {
-					@Override
-					public boolean shouldReplace(BackpackScreen screen, Button button) {
-						if (!(button instanceof MiniInventoryButton)) {
-							return false;
-						}
-						try {
-							//this logic isn't ideal by far, but best that can be used to identify the actual sort backpack button
-							MiniInventoryButton miniInventoryButton = ((MiniInventoryButton) button);
-							int type = ObfuscationReflectionHelper.getPrivateValue(MiniInventoryButton.class, miniInventoryButton, "type");
-							Slot slot = screen.getMenu().getSlot(8);
-							int x = screen.getGuiLeft() + slot.x + 6;
-							int y = screen.getGuiTop() + slot.y - 13;
-							return type == 0 && button.x == x && button.y == y;
-						}
-						catch (ObfuscationReflectionHelper.UnableToFindFieldException | ObfuscationReflectionHelper.UnableToAccessFieldException | NullPointerException ex) {
-							SophisticatedBackpacks.LOGGER.error("Error checking for Quark Sort button ", ex);
-							return false;
-						}
-					}
-
-					@Override
-					public Button replace(BackpackScreen screen, Button button) {
-						return new MiniInventoryButton(screen, 0, button.x - screen.getGuiLeft(), button.y - screen.getGuiTop(), "quark.gui.button.sort_container", b -> screen.getMenu().sort());
-					}
-				});
+				BackpackScreen.setButtonReplacer(new QuarkButtonReplacer());
 			}
 		});
+		PacketHandler.registerMessage(TransferMessage.class, TransferMessage::encode, TransferMessage::decode, TransferMessage::onMessage);
 	}
+
 }

--- a/src/main/java/net/p3pp3rf1y/sophisticatedbackpacks/compat/quark/TransferMessage.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedbackpacks/compat/quark/TransferMessage.java
@@ -1,0 +1,57 @@
+package net.p3pp3rf1y.sophisticatedbackpacks.compat.quark;
+
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.entity.player.ServerPlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.network.PacketBuffer;
+import net.minecraftforge.fml.network.NetworkEvent;
+import net.minecraftforge.items.CapabilityItemHandler;
+import net.p3pp3rf1y.sophisticatedbackpacks.backpack.wrapper.BackpackInventoryHandler;
+import net.p3pp3rf1y.sophisticatedbackpacks.common.gui.BackpackContainer;
+import net.p3pp3rf1y.sophisticatedbackpacks.util.InventoryHelper;
+
+import javax.annotation.Nullable;
+import java.util.function.Supplier;
+
+public class TransferMessage {
+	private final boolean isRestock;
+
+	public TransferMessage(boolean isRestock) {
+		this.isRestock = isRestock;
+	}
+
+	public static void encode(TransferMessage msg, PacketBuffer packetBuffer) {
+		packetBuffer.writeBoolean(msg.isRestock);
+	}
+
+	public static TransferMessage decode(PacketBuffer packetBuffer) {
+		return new TransferMessage(packetBuffer.readBoolean());
+	}
+
+	static void onMessage(TransferMessage msg, Supplier<NetworkEvent.Context> contextSupplier) {
+		NetworkEvent.Context context = contextSupplier.get();
+		context.enqueueWork(() -> handleMessage(context.getSender(), msg));
+		context.setPacketHandled(true);
+	}
+
+	private static void handleMessage(@Nullable ServerPlayerEntity player, TransferMessage msg) {
+		if (player == null || !(player.containerMenu instanceof BackpackContainer)) {
+			return;
+		}
+		BackpackContainer backpackContainer = (BackpackContainer) player.containerMenu;
+		BackpackInventoryHandler backpackInventory = backpackContainer.getBackpackWrapper().getInventoryHandler();
+		if (msg.isRestock) {
+			player.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY).ifPresent(playerInv -> {
+				InventoryHelper.transfer(backpackInventory, playerInv, s -> {});
+			});
+		} else {
+			PlayerInventory inv = player.inventory;
+			for(int i = PlayerInventory.getSelectionSize(); i < inv.items.size(); i++) {
+				ItemStack stackAt = inv.getItem(i);
+				if(!stackAt.isEmpty()) {
+					inv.setItem(i, backpackInventory.insertItem(stackAt, false));
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
…e with backpack, also made backpack inventory slots independent of SlotItemHandler to prevent Quark's transfer keybinds from being able to run their logic