### PR TITLE
fix: 🐛 Fixes display of some recipes in JEI so that when overriden by…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.daemon=false
 minecraft_version=1.18.2
 forge_version=40.1.17
-mod_version=3.17.4
+mod_version=3.17.5
 jei_mc_version=1.18.2
 jei_version=9.7.0+
 curios_version=1.18.2-5.0.6.+

--- a/src/main/java/net/p3pp3rf1y/sophisticatedbackpacks/init/ModItems.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedbackpacks/init/ModItems.java
@@ -26,8 +26,10 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.DispenserBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.extensions.IForgeMenuType;
 import net.minecraftforge.common.util.LazyOptional;
+import net.minecraftforge.event.AddReloadListenerEvent;
 import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.fml.DistExecutor;
@@ -258,6 +260,12 @@ public class ModItems {
 		ENTITIES.register(modBus);
 		modBus.addGenericListener(MenuType.class, ModItems::registerContainers);
 		modBus.addGenericListener(RecipeSerializer.class, ModItems::registerRecipeSerializers);
+		MinecraftForge.EVENT_BUS.addListener(ModItems::onResourceReload);
+	}
+
+	private static void onResourceReload(AddReloadListenerEvent event) {
+		BackpackUpgradeRecipe.REGISTERED_RECIPES.clear();
+		SmithingBackpackUpgradeRecipe.REGISTERED_RECIPES.clear();
 	}
 
 	private static final UpgradeContainerType<PickupUpgradeWrapper, ContentsFilteredUpgradeContainer<PickupUpgradeWrapper>> PICKUP_BASIC_TYPE = new UpgradeContainerType<>(ContentsFilteredUpgradeContainer::new);


### PR DESCRIPTION
… kubejs or similar tools the default ones don't appear in there