### PR TITLE
fix: 🐛 Moved initialization of world in RecipeHelper to core to stop …

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.daemon=false
 minecraft_version=1.18.2
 forge_version=40.1.17
-mod_version=3.17.9
+mod_version=3.17.10
 jei_mc_version=1.18.2
 jei_version=9.7.0+
 curios_version=1.18.2-5.0.6.+

--- a/src/main/java/net/p3pp3rf1y/sophisticatedbackpacks/SophisticatedBackpacks.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedbackpacks/SophisticatedBackpacks.java
@@ -1,15 +1,12 @@
 package net.p3pp3rf1y.sophisticatedbackpacks;
 
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.item.CreativeModeTab;
-import net.minecraft.world.level.Level;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.MinecraftForgeClient;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.AddReloadListenerEvent;
 import net.minecraftforge.event.RegisterCommandsEvent;
-import net.minecraftforge.event.server.ServerStartedEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
@@ -31,7 +28,6 @@ import net.p3pp3rf1y.sophisticatedbackpacks.init.ModItems;
 import net.p3pp3rf1y.sophisticatedbackpacks.init.ModLoot;
 import net.p3pp3rf1y.sophisticatedbackpacks.network.SBPPacketHandler;
 import net.p3pp3rf1y.sophisticatedbackpacks.registry.RegistryLoader;
-import net.p3pp3rf1y.sophisticatedcore.util.RecipeHelper;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -63,7 +59,6 @@ public class SophisticatedBackpacks {
 		ModLoot.init(modBus);
 
 		IEventBus eventBus = MinecraftForge.EVENT_BUS;
-		eventBus.addListener(SophisticatedBackpacks::serverStarted);
 		eventBus.addListener(SophisticatedBackpacks::registerCommands);
 		eventBus.addListener(this::onAddReloadListener);
 	}
@@ -79,13 +74,6 @@ public class SophisticatedBackpacks {
 	private static void clientSetup(FMLClientSetupEvent event) {
 		KeybindHandler.register(event);
 		MinecraftForgeClient.registerTooltipComponentFactory(BackpackItem.BackpackContentsTooltip.class, ClientBackpackContentsTooltip::new);
-	}
-
-	private static void serverStarted(ServerStartedEvent event) {
-		ServerLevel world = event.getServer().getLevel(Level.OVERWORLD);
-		if (world != null) {
-			RecipeHelper.setWorld(world);
-		}
 	}
 
 	private static void registerCommands(RegisterCommandsEvent event) {


### PR DESCRIPTION
…crashes with compacting upgrade or cooking upgrades when only Sophisticated Storage is included in the pack