### PR TITLE
fix: 🐛 Made stashing only work on right click again, left click will …

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.daemon=false
 minecraft_version=1.18.2
 forge_version=40.1.30
-mod_version=3.18.44
+mod_version=3.18.45
 jei_mc_version=1.18.2
 jei_version=9.7.0+
 curios_version=1.18.2-5.0.6.+

--- a/src/main/java/net/p3pp3rf1y/sophisticatedbackpacks/backpack/BackpackItem.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedbackpacks/backpack/BackpackItem.java
@@ -409,7 +409,7 @@ public class BackpackItem extends ItemBase implements IStashStorageItem {
 
 	@Override
 	public boolean overrideStackedOnOther(ItemStack storageStack, Slot slot, ClickAction action, Player player) {
-		if (!slot.mayPickup(player)) {
+		if (!slot.mayPickup(player) || action != ClickAction.SECONDARY) {
 			return super.overrideStackedOnOther(storageStack, slot, action, player);
 		}
 
@@ -426,7 +426,7 @@ public class BackpackItem extends ItemBase implements IStashStorageItem {
 
 	@Override
 	public boolean overrideOtherStackedOnMe(ItemStack storageStack, ItemStack otherStack, Slot slot, ClickAction action, Player player, SlotAccess carriedAccess) {
-		if (!slot.mayPlace(storageStack)) {
+		if (!slot.mayPlace(storageStack) || action != ClickAction.SECONDARY) {
 			return super.overrideOtherStackedOnMe(storageStack, otherStack, slot, action, player, carriedAccess);
 		}
 


### PR DESCRIPTION
…only switch the two stacks as it used to