### PR TITLE
fix: 🐛 Made stashing only work on right click again, left click will …

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.daemon=false
 minecraft_version=1.19.2
 forge_version=43.2.7
-mod_version=3.18.44
+mod_version=3.18.45
 jei_mc_version=1.19.1-forge
 jei_version=11.2.0.244
 curios_version=1.19.2-5.1.1.+

--- a/src/main/java/net/p3pp3rf1y/sophisticatedbackpacks/backpack/BackpackItem.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedbackpacks/backpack/BackpackItem.java
@@ -405,7 +405,7 @@ public class BackpackItem extends ItemBase implements IStashStorageItem {
 
 	@Override
 	public boolean overrideStackedOnOther(ItemStack storageStack, Slot slot, ClickAction action, Player player) {
-		if (!slot.mayPickup(player)) {
+		if (!slot.mayPickup(player) || action != ClickAction.SECONDARY) {
 			return super.overrideStackedOnOther(storageStack, slot, action, player);
 		}
 
@@ -422,7 +422,7 @@ public class BackpackItem extends ItemBase implements IStashStorageItem {
 
 	@Override
 	public boolean overrideOtherStackedOnMe(ItemStack storageStack, ItemStack otherStack, Slot slot, ClickAction action, Player player, SlotAccess carriedAccess) {
-		if (!slot.mayPlace(storageStack)) {
+		if (!slot.mayPlace(storageStack) || action != ClickAction.SECONDARY) {
 			return super.overrideOtherStackedOnMe(storageStack, otherStack, slot, action, player, carriedAccess);
 		}
 


### PR DESCRIPTION
…only switch the two stacks as it used to