### PR TITLE
Add copper backpack block to list of blocks associated with the backpack block entity

### DIFF
--- a/src/main/java/net/p3pp3rf1y/sophisticatedbackpacks/init/ModBlocks.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedbackpacks/init/ModBlocks.java
@@ -27,7 +27,7 @@ public class ModBlocks {
 
 	@SuppressWarnings("ConstantConditions") //no datafixer type needed
 	public static final RegistryObject<BlockEntityType<BackpackBlockEntity>> BACKPACK_TILE_TYPE = BLOCK_ENTITY_TYPES.register("backpack", () ->
-			BlockEntityType.Builder.of(BackpackBlockEntity::new, BACKPACK.get(), IRON_BACKPACK.get(), GOLD_BACKPACK.get(), DIAMOND_BACKPACK.get(), NETHERITE_BACKPACK.get())
+			BlockEntityType.Builder.of(BackpackBlockEntity::new, BACKPACK.get(), COPPER_BACKPACK.get(), IRON_BACKPACK.get(), GOLD_BACKPACK.get(), DIAMOND_BACKPACK.get(), NETHERITE_BACKPACK.get())
 					.build(null));
 
 	public static void registerHandlers(IEventBus modBus) {


### PR DESCRIPTION
The copper backpack block was missing from the block entity list and was logging the following errors after a level load: 
`Block entity sophisticatedbackpacks:backpack @ BlockPos{x=-1545, y=43, z=1424} state Block{sophisticatedbackpacks:copper_backpack}[battery=false,facing=west,left_tank=false,right_tank=false,waterlogged=false] invalid for ticking:`

I haven't checked any other branches, but this is probably also missing on some other versions.