### PR TITLE
fix: 🐛 Fixed backpack to just close gui instead of crashing out of wo…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.daemon=false
 
 mod_id=sophisticatedbackpacks
 mod_group_id=sophisticatedbackpacks
-mod_version=3.20.9
+mod_version=3.20.10
 sonar_project_key=sophisticatedbackpacks:SophisticatedBackpacks
 github_package_url=https://maven.pkg.github.com/P3pp3rF1y/SophisticatedBackpacks
 

--- a/src/main/java/net/p3pp3rf1y/sophisticatedbackpacks/client/gui/BackpackScreen.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedbackpacks/client/gui/BackpackScreen.java
@@ -1,6 +1,8 @@
 package net.p3pp3rf1y.sophisticatedbackpacks.client.gui;
 
 import com.mojang.blaze3d.platform.InputConstants;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.screens.inventory.InventoryScreen;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.player.Inventory;
@@ -51,5 +53,13 @@ public class BackpackScreen extends StorageScreenBase<BackpackContainer> {
 	@Override
 	protected String getStorageSettingsTabTooltip() {
 		return SBPTranslationHelper.INSTANCE.translGui("settings.tooltip");
+	}
+
+	@Override
+	public void render(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTicks) {
+		super.render(guiGraphics, mouseX, mouseY, partialTicks);
+		if (getMenu().getNumberOfStorageInventorySlots() == 0 && Minecraft.getInstance().player != null) {
+			Minecraft.getInstance().player.closeContainer();
+		}
 	}
 }


### PR DESCRIPTION
…rld if player happens to press backpack open key at the same time they click the backpack out of slot causing client not having the backpack in slot when server had it and already started opening gui