### PR TITLE
fix: 🐛 Fixed sorting to trigger when cursor is anywhere outside of st…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.daemon=false
 
 mod_id=sophisticatedbackpacks
 mod_group_id=sophisticatedbackpacks
-mod_version=3.20.11
+mod_version=3.20.12
 sonar_project_key=sophisticatedbackpacks:SophisticatedBackpacks
 github_package_url=https://maven.pkg.github.com/P3pp3rF1y/SophisticatedBackpacks
 

--- a/src/main/java/net/p3pp3rf1y/sophisticatedbackpacks/client/KeybindHandler.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedbackpacks/client/KeybindHandler.java
@@ -135,7 +135,7 @@ public class KeybindHandler {
 			double mouseX = mh.xpos() * mc.getWindow().getGuiScaledWidth() / mc.getWindow().getScreenWidth();
 			double mouseY = mh.ypos() * mc.getWindow().getGuiScaledHeight() / mc.getWindow().getScreenHeight();
 			Slot selectedSlot = screen.findSlot(mouseX, mouseY);
-			if (selectedSlot != null && container.isNotPlayersInventorySlot(selectedSlot.index)) {
+			if (selectedSlot == null || container.isNotPlayersInventorySlot(selectedSlot.index)) {
 				container.sort();
 				return true;
 			}


### PR DESCRIPTION
…orage slots. Fixes the behavior where sorting mods would sort sophisticated inventories when middle click is used with cursor outside of any slot which caused item loss for example when stack upgrades were used.