### PR TITLE
Added config options for controlling backpack spawns

### DIFF
--- a/src/main/java/net/p3pp3rf1y/sophisticatedbackpacks/Config.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedbackpacks/Config.java
@@ -231,6 +231,15 @@ public class Config {
 			public final ModConfigSpec.BooleanValue dropToFakePlayers;
 			public final ModConfigSpec.DoubleValue backpackDropChance;
 			public final ModConfigSpec.DoubleValue lootingChanceIncreasePerLevel;
+			public final ModConfigSpec.IntValue leatherWeight;
+			public final ModConfigSpec.IntValue copperWeight;
+			public final ModConfigSpec.IntValue ironWeight;
+			public final ModConfigSpec.IntValue goldWeight;
+			public final ModConfigSpec.IntValue diamondWeight;
+			public final ModConfigSpec.IntValue netheriteWeight;
+			public final ModConfigSpec.IntValue difficultyNormalLockout;
+			public final ModConfigSpec.IntValue difficultyHardLockout;
+			public final ModConfigSpec.BooleanValue localDifficultyEffectsBackpackSpawns;
 			public final ModConfigSpec.ConfigValue<List<? extends String>> entityLootTableList;
 			public final ModConfigSpec.ConfigValue<List<? extends String>> discBlockList;
 			@Nullable
@@ -254,6 +263,18 @@ public class Config {
 				dropToFakePlayers = builder.comment("Determines whether backpack drops to fake players if killed by them in addition to real ones that it always drops to").define("dropToFakePlayers", false);
 				backpackDropChance = builder.comment("Chance of mob dropping backpack when killed by player").defineInRange("backpackDropChance", 0.5, 0, 1);
 				lootingChanceIncreasePerLevel = builder.comment("Chance increase per looting level of mob dropping backpack").defineInRange("lootingChanceIncreasePerLevel", 0.15, 0, 0.3);
+				leatherWeight = builder.comment("Weight of selecting a Leather Backpack when an entity spawns with a backpack").defineInRange("leatherWeight", 625, 0, 9999);
+				copperWeight = builder.comment("Weight of selecting a Copper Backpack when an entity spawns with a backpack").defineInRange("copperWeight", 250, 0, 9999);
+				ironWeight = builder.comment("Weight of selecting a Iron Backpack when an entity spawns with a backpack").defineInRange("ironWeight", 125, 0, 9999);
+				goldWeight = builder.comment("Weight of selecting a Gold Backpack when an entity spawns with a backpack").defineInRange("goldWeight", 25, 0, 9999);
+				diamondWeight = builder.comment("Weight of selecting a Diamond Backpack when an entity spawns with a backpack").defineInRange("diamondWeight", 5, 0, 9999);
+				netheriteWeight = builder.comment("Weight of selecting a Netherite Backpack when an entity spawns with a backpack").defineInRange("netheriteWeight", 1, 0, 9999);
+				difficultyNormalLockout = builder.comment("Minimum tier of backpack mobs are equipped with in Normal difficulty (0 is leather)")
+						.defineInRange("difficultyNormalLockout", 1, 0, 5);
+				difficultyHardLockout = builder.comment("Minimum tier of backpack mobs are equipped with in Hard difficulty (0 is leather)")
+						.defineInRange("difficultyHardLockout", 2, 0, 5);
+				localDifficultyEffectsBackpackSpawns = builder.comment("If local difficulty is taken into consideration when determining the difficulty. If local difficulty is high enough then it will use the above lockout pool of a higher difficulty")
+								.define("localDifficultyEffectsBackpackSpawns", true);
 				builder.pop();
 			}
 

--- a/src/main/java/net/p3pp3rf1y/sophisticatedbackpacks/common/EntityBackpackAdditionHandler.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedbackpacks/common/EntityBackpackAdditionHandler.java
@@ -94,24 +94,24 @@ public class EntityBackpackAdditionHandler {
 	);
 
 	private static final List<WeightedElement<BackpackAddition>> BACKPACK_CHANCES = List.of(
-			new WeightedElement<>(1, new BackpackAddition(ModItems.NETHERITE_BACKPACK.get(), 4,
+			new WeightedElement<>(Config.SERVER.entityBackpackAdditions.netheriteWeight.getAsInt(), new BackpackAddition(ModItems.NETHERITE_BACKPACK.get(), 4,
 					HELMET_CHANCES.subList(0, 1), LEGGINGS_CHANCES.subList(0, 1), BOOTS_CHANCES.subList(0, 1))),
-			new WeightedElement<>(5, new BackpackAddition(ModItems.DIAMOND_BACKPACK.get(), 3,
+			new WeightedElement<>(Config.SERVER.entityBackpackAdditions.diamondWeight.getAsInt(), new BackpackAddition(ModItems.DIAMOND_BACKPACK.get(), 3,
 					HELMET_CHANCES.subList(0, 2), LEGGINGS_CHANCES.subList(0, 2), BOOTS_CHANCES.subList(0, 2))),
-			new WeightedElement<>(25, new BackpackAddition(ModItems.GOLD_BACKPACK.get(), 2,
+			new WeightedElement<>(Config.SERVER.entityBackpackAdditions.goldWeight.getAsInt(), new BackpackAddition(ModItems.GOLD_BACKPACK.get(), 2,
 					HELMET_CHANCES.subList(1, 3), LEGGINGS_CHANCES.subList(1, 3), BOOTS_CHANCES.subList(1, 3))),
-			new WeightedElement<>(125, new BackpackAddition(ModItems.IRON_BACKPACK.get(), 1,
+			new WeightedElement<>(Config.SERVER.entityBackpackAdditions.ironWeight.getAsInt(), new BackpackAddition(ModItems.IRON_BACKPACK.get(), 1,
 					HELMET_CHANCES.subList(2, 4), LEGGINGS_CHANCES.subList(2, 4), BOOTS_CHANCES.subList(2, 4))),
-			new WeightedElement<>(250, new BackpackAddition(ModItems.COPPER_BACKPACK.get(), 1,
+			new WeightedElement<>(Config.SERVER.entityBackpackAdditions.copperWeight.getAsInt(), new BackpackAddition(ModItems.COPPER_BACKPACK.get(), 1,
 					HELMET_CHANCES.subList(2, 4), LEGGINGS_CHANCES.subList(3, 5), BOOTS_CHANCES.subList(3, 5))),
-			new WeightedElement<>(625, new BackpackAddition(ModItems.BACKPACK.get(), 0,
+			new WeightedElement<>(Config.SERVER.entityBackpackAdditions.leatherWeight.getAsInt(), new BackpackAddition(ModItems.BACKPACK.get(), 0,
 					HELMET_CHANCES.subList(3, 5), LEGGINGS_CHANCES.subList(3, 5), BOOTS_CHANCES.subList(3, 5)))
 	);
 
 	private static final Map<Integer, List<WeightedElement<BackpackAddition>>> DIFFICULTY_BACKPACK_CHANCES = Map.of(
 			0, BACKPACK_CHANCES,
-			1, BACKPACK_CHANCES.subList(1, 5),
-			2, BACKPACK_CHANCES.subList(2, 5)
+			1, BACKPACK_CHANCES.subList(Config.SERVER.entityBackpackAdditions.difficultyNormalLockout.getAsInt(), 5),
+			2, BACKPACK_CHANCES.subList(Config.SERVER.entityBackpackAdditions.difficultyHardLockout.getAsInt(), 5)
 	);
 
 	static void addBackpack(Monster monster, LevelAccessor level) {
@@ -122,8 +122,10 @@ public class EntityBackpackAdditionHandler {
 		}
 
 		float localDifficulty = level.getCurrentDifficultyAt(monster.blockPosition()).getEffectiveDifficulty();
-		int index = Ints.constrainToRange((int) Math.floor(DIFFICULTY_BACKPACK_CHANCES.size() / MAX_LOCAL_DIFFICULTY * localDifficulty - 0.1f), 0, DIFFICULTY_BACKPACK_CHANCES.size());
-
+		int index = Config.SERVER.entityBackpackAdditions.localDifficultyEffectsBackpackSpawns.getAsBoolean() ? 
+				Ints.constrainToRange((int) Math.floor(DIFFICULTY_BACKPACK_CHANCES.size() / MAX_LOCAL_DIFFICULTY * localDifficulty - 0.1f), 0, DIFFICULTY_BACKPACK_CHANCES.size() - 1) :
+				Ints.constrainToRange(level.getDifficulty().getId() - 1, 0, DIFFICULTY_BACKPACK_CHANCES.size() - 1);
+		
 		RandHelper.getRandomWeightedElement(rnd, DIFFICULTY_BACKPACK_CHANCES.get(index)).ifPresent(backpackAddition -> {
 			ItemStack backpack = new ItemStack(backpackAddition.getBackpackItem());
 			int minDifficulty = backpackAddition.getMinDifficulty();


### PR DESCRIPTION
There is config for; weights of individual backpacks, the lockouts for different difficulties and wether local difficulty affects it or not.

Default config values are set so that no behavior is changed with this pull request.